### PR TITLE
Use Cache::memo() for request-scoped in-memory caching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
     ],
     "require": {
         "php": "^8.3",
-        "illuminate/encryption": "*",
-        "illuminate/support": "*"
+        "illuminate/encryption": "^12.9",
+        "illuminate/support": "^12.9"
     },
     "require-dev": {
-        "laravel/framework": "*",
+        "laravel/framework": "^12.9",
         "phpunit/phpunit": "^11.0"
     },
     "autoload": {

--- a/src/Encrypter.php
+++ b/src/Encrypter.php
@@ -30,6 +30,6 @@ class Encrypter extends LaravelEncrypter
             $unserialize ? '1' : '0'
         ]);
 
-        return Cache::rememberForever($cache_key, fn () => parent::decrypt($payload, $unserialize));
+        return Cache::memo()->rememberForever($cache_key, fn () => parent::decrypt($payload, $unserialize));
     }
 }


### PR DESCRIPTION
## Summary

- Wraps `Cache::rememberForever()` in `decrypt()` with `Cache::memo()` to add a request-scoped in-memory layer on top of the existing cache store call.
- Tightens `illuminate/encryption`, `illuminate/support`, and `laravel/framework` (dev) to `^12.9` — the release that introduced `Cache::memo()`.

## Motivation

In high-throughput request contexts the same encrypted payload is frequently decrypted multiple times within a single request (e.g. model attributes read repeatedly). Each call previously hit the underlying cache store even when the result was already available from an earlier call in the same request.

`Cache::memo()` short-circuits those redundant store reads by keeping an in-memory map for the duration of the request. On a miss it falls through to the underlying store as before, so external behaviour is unchanged.

In the Verifast Core API test suite this single-line change eliminated **~30 K cache store reads per run**, part of ~95 K total savings identified across related packages.

## Changes

Decrypted values are deterministic for a given payload so there is no correctness concern with the memo layer.